### PR TITLE
[typeof][msvc-8.0] bug fix related to problem with included version of Boost.Test on msvc-8.0

### DIFF
--- a/include/boost/typeof/msvc/typeof_impl.hpp
+++ b/include/boost/typeof/msvc/typeof_impl.hpp
@@ -168,11 +168,11 @@ namespace boost
         {
             typedef char(*type)[encode_type<T>::value];
         };
-        template<typename T> typename disable_if<
+        template<typename T> typename boost::disable_if<
             typename is_function<T>::type,
             typename sizer<T>::type>::type encode_start(T const&);
 
-        template<typename T> typename enable_if<
+        template<typename T> typename boost::enable_if<
             typename is_function<T>::type,
             typename sizer<T>::type>::type encode_start(T&);
         template<typename Organizer, typename T>


### PR DESCRIPTION
When both boost/utility/enable_if.hpp and boost/test/included/unit_test.hpp are included,
msvc-8.0 cannot figure out whether the enable_if and disable_if used in te typeof implementation
for msvc-8.0 is that in the boost namespace or that in the boost::unit_test::decorator namespace.

Proposed solution: explicitly qualify enable_if and disable_if with the boost namespace.

This problem has appeared in recent boost/geometry unit tests, on msvc-8.0 platforms, where the included version of the unit test is used.

For example see:
http://www.boost.org/development/tests/develop/developer/output/teeks99-02a-win2008-64on64-boost-bin-v2-libs-geometry-test-algorithms-difference_linear_linear-test-msvc-8-0-debug-asynch-exceptions-on-threading-multi.html
for the results of the unit test, and:
https://github.com/boostorg/geometry/blob/develop/test/algorithms/difference_linear_linear.cpp
for the source code of the unit test.
