### PR TITLE
Fix compilation error with MSC+Clang

### DIFF
--- a/include/boost/typeof/typeof.hpp
+++ b/include/boost/typeof/typeof.hpp
@@ -49,7 +49,7 @@
 #       endif
 #   endif
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #   ifndef BOOST_TYPEOF_EMULATION
 #       ifndef BOOST_TYPEOF_NATIVE
 #           define BOOST_TYPEOF_NATIVE


### PR DESCRIPTION
Check `defined(__clang__)` explicitly because with MSVC+Clang `__GNUC__` is not defined.
