### PR TITLE
Fix for clang on windows

### DIFF
--- a/include/boost/typeof/typeof.hpp
+++ b/include/boost/typeof/typeof.hpp
@@ -49,7 +49,7 @@
 #       endif
 #   endif
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #   ifndef BOOST_TYPEOF_EMULATION
 #       ifndef BOOST_TYPEOF_NATIVE
 #           define BOOST_TYPEOF_NATIVE


### PR DESCRIPTION
Clang in msvc compatibility mode does not compile the msvc-specific code branch, it does however, cope with **typeof** perfectly well.
