### PR TITLE
support for IBM XL C/C++ compiler family __typeof__

### DIFF
--- a/include/boost/typeof/typeof.hpp
+++ b/include/boost/typeof/typeof.hpp
@@ -161,6 +161,13 @@
 #         define BOOST_TYPEOF_KEYWORD __typeof__
 #     endif
 #   endif
+#elif defined(__IBM__TYPEOF__)
+#   ifndef BOOST_TYPEOF_EMULATION
+#       ifndef BOOST_TYPEOF_NATIVE
+#           define BOOST_TYPEOF_NATIVE
+#       endif
+#       define BOOST_TYPEOF_KEYWORD __typeof__
+#   endif
 #else //unknown compiler
 #   ifndef BOOST_TYPEOF_NATIVE
 #       ifndef BOOST_TYPEOF_EMULATION


### PR DESCRIPTION
I added native typeof support for the IBM XL C/C++ compiler family.
