### PR TITLE
Disable MSVC typeof hack for VS2017

### DIFF
--- a/include/boost/typeof/typeof.hpp
+++ b/include/boost/typeof/typeof.hpp
@@ -100,7 +100,7 @@
 #       define MSVC_TYPEOF_HACK
 #   endif
 #elif defined(_MSC_VER)
-#   if (_MSC_VER >= 1310)  // 7.1 ->
+#   if (_MSC_VER >= 1310) && (_MSC_VER < 1910)  // 7.1 <= ver < 14.1
 #       ifndef BOOST_TYPEOF_EMULATION
 #           ifndef BOOST_TYPEOF_NATIVE
 #               ifndef _MSC_EXTENSIONS


### PR DESCRIPTION
Disable MSVC typeof hack for VS2017 to support flag `/permissive-`