### PR TITLE
enable use of msvc compiler option /permissive-

### DIFF
--- a/include/boost/typeof/decltype.hpp
+++ b/include/boost/typeof/decltype.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2006 Arkadiy Vertleyb
+// Copyright (C) 2017 Daniela Engert
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_TYPEOF_DECLTYPE_HPP_INCLUDED
+# define BOOST_TYPEOF_DECLTYPE_HPP_INCLUDED
+
+#include <boost/type_traits/remove_cv.hpp> 
+#include <boost/type_traits/remove_reference.hpp> 
+
+namespace boost { namespace type_of {
+    template<typename T>
+        using remove_cv_ref_t = typename remove_cv<typename remove_reference<T>::type>::type;
+}}
+
+#define BOOST_TYPEOF(expr) boost::type_of::remove_cv_ref_t<decltype(expr)>
+#define BOOST_TYPEOF_TPL BOOST_TYPEOF
+
+#define BOOST_TYPEOF_NESTED_TYPEDEF_TPL(name,expr) \
+    struct name {\
+        typedef BOOST_TYPEOF_TPL(expr) type;\
+    };
+
+#define BOOST_TYPEOF_NESTED_TYPEDEF(name,expr) \
+    struct name {\
+        typedef BOOST_TYPEOF(expr) type;\
+    };
+
+#define BOOST_TYPEOF_REGISTER_TYPE(x)
+#define BOOST_TYPEOF_REGISTER_TEMPLATE(x, params)
+
+#endif //BOOST_TYPEOF_DECLTYPE_HPP_INCLUDED
+

--- a/include/boost/typeof/typeof.hpp
+++ b/include/boost/typeof/typeof.hpp
@@ -13,7 +13,15 @@
 #   error both typeof emulation and native mode requested
 #endif
 
-#if defined(__COMO__)
+#include <boost/config.hpp>
+
+#if !defined(BOOST_NO_CXX11_DECLTYPE) && !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES) && !defined(BOOST_TYPEOF_EMULATION)
+#   define BOOST_TYPEOF_DECLTYPE
+#   ifndef BOOST_TYPEOF_NATIVE
+#       define BOOST_TYPEOF_NATIVE
+#   endif
+
+#elif defined(__COMO__)
 #   ifdef __GNUG__
 #       ifndef BOOST_TYPEOF_EMULATION
 #           ifndef BOOST_TYPEOF_NATIVE
@@ -203,7 +211,11 @@
 #elif defined(BOOST_TYPEOF_NATIVE)
 #   define BOOST_TYPEOF_TEXT "using native typeof"
 #   include <boost/typeof/message.hpp>
-#   include <boost/typeof/native.hpp>
+#   ifdef BOOST_TYPEOF_DECLTYPE
+#       include <boost/typeof/decltype.hpp>
+#   else
+#       include <boost/typeof/native.hpp>
+#   endif
 #else
 #   error typeof configuration error
 #endif


### PR DESCRIPTION
The compiler hack used to emulate __typeof__ on msvc no longer works when compiler option /permissive- is engaged. Rather than preying on a compiler bug take advantage of modern c++ instead.

Signed-off-by: Daniela Engert <dani@ngrt.de>