### PR TITLE
clean compile; add missing declaration

### DIFF
--- a/include/boost/typeof/msvc/typeof_impl.hpp
+++ b/include/boost/typeof/msvc/typeof_impl.hpp
@@ -100,6 +100,9 @@ namespace boost
         template<typename ID, typename T>
         struct msvc_extract_type : msvc_extract_type<ID,msvc_extract_type_default_param>
         {
+            template<bool>
+            struct id2type_impl;
+            
             template<>
             struct id2type_impl<true>  //VC8.0 specific bugfeature
             {


### PR DESCRIPTION
There is a compilation problem with MSVC 15.7.1 and /std:c++latest.

    1>c:\libraries\boost_1_64_0\boost\typeof\msvc\typeof_impl.hpp(128): error C2988: unrecognizable template declaration/definition
    1>c:\libraries\boost_1_64_0\boost\typeof\msvc\typeof_impl.hpp(136): note: see reference to class template instantiation 'boost::type_of::msvc_extract_type<ID,T>' being compiled
    1>c:\libraries\boost_1_64_0\boost\typeof\msvc\typeof_impl.hpp(128): error C2143: syntax error: missing ';' before '<'
    1>c:\libraries\boost_1_64_0\boost\typeof\msvc\typeof_impl.hpp(128): error C2913: explicit specialization; 'boost::type_of::id2type_impl' is not a specialization of a class template
    1>c:\libraries\boost_1_64_0\boost\typeof\msvc\typeof_impl.hpp(128): error C2059: syntax error: '<'
    1>c:\libraries\boost_1_64_0\boost\typeof\msvc\typeof_impl.hpp(129): error C2334: unexpected token(s) preceding '{'; skipping apparent function body

The PR fix it.
