### PR TITLE
Test BOOST_AUTO in data member

### DIFF
--- a/test/data_member.cpp
+++ b/test/data_member.cpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2006 Arkadiy Vertleyb
+// Copyright (C) 2023 Serg Kryvonos
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (http://www.boost.org/LICENSE_1_0.txt)
 
@@ -9,3 +10,8 @@ struct x;
 BOOST_TYPEOF_REGISTER_TYPE(x)
 
 BOOST_STATIC_ASSERT(boost::type_of::test<double x::*>::value);
+
+class Data {
+    BOOST_AUTO(member, 1);
+    static BOOST_AUTO(member, 2);
+};


### PR DESCRIPTION
Covers broken use-case (regression): https://github.com/ohhmm/skrypt/blob/b13613cd6458991f1e693bbacb6cb2cb146ac39a/libskrypt/skrypt.h#L18