### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -7,9 +7,9 @@ import project ;
 
 project /boost/typeof
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/config//boost_config
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/typeof
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -10,8 +10,6 @@ import project ;
 project /boost/typeof
     : common-requirements
         <library>/boost/config//boost_config
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -9,12 +9,11 @@ constant boost_dependencies :
     /boost/config//boost_config ;
 
 project /boost/typeof
-    : common-requirements
-        <include>include
     ;
 
 explicit
-    [ alias boost_typeof : : : : <library>$(boost_dependencies) ]
+    [ alias boost_typeof : : :
+        : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_typeof test ]
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,22 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/typeof
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_typeof ]
+    [ alias all : boost_typeof test ]
+    ;
+
+call-if : boost-library typeof
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/typeof

--- a/build.jam
+++ b/build.jam
@@ -5,16 +5,19 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config ;
+
 project /boost/typeof
     : common-requirements
-        <library>/boost/config//boost_config
         <include>include
     ;
 
 explicit
-    [ alias boost_typeof ]
+    [ alias boost_typeof : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_typeof test ]
     ;
 
 call-if : boost-library typeof
     ;
+

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -8,6 +8,11 @@
 import testing ;
 import set ;
 
+project : requirements
+    <source>/boost/core//boost_core
+    <source>/boost/lexical_cast//boost_lexical_cast
+    ;
+
 # The special requirement is not ported yet.
 #
 #local rule special-requirements ( toolset variant : properties * )

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -9,8 +9,8 @@ import testing ;
 import set ;
 
 project : requirements
-    <source>/boost/core//boost_core
-    <source>/boost/lexical_cast//boost_lexical_cast
+    <library>/boost/core//boost_core
+    <library>/boost/lexical_cast//boost_lexical_cast
     ;
 
 # The special requirement is not ported yet.
@@ -27,7 +27,7 @@ project : requirements
 #                [ replace-properties $(properties) : <build>no ] ;
 #        }
 #    }
-#    
+#
 #    return $(properties) ;
 #}
 
@@ -36,8 +36,8 @@ rule typeof-test ( source )
    return [ compile $(source) : <define>BOOST_TYPEOF_NATIVE :
                 $(source:B)_native ]
           [ compile $(source) : <define>BOOST_TYPEOF_EMULATION :
-                $(source:B)_emulation ] 
-          ;        
+                $(source:B)_emulation ]
+          ;
 }
 
 rule all-tests ( )
@@ -51,12 +51,12 @@ rule all-tests ( )
     all += [ run odr1.cpp odr2.cpp : : : <define>BOOST_TYPEOF_NATIVE :
                 odr_native ] ;
     all += [ run odr1.cpp odr2.cpp : : : <define>BOOST_TYPEOF_EMULATION :
-                odr_emulation ] ;		
-    all += [ run odr_no_uns1.cpp odr_no_uns2.cpp : : : <define>BOOST_TYPEOF_EMULATION : 
-                odr_no_uns ] ;		
-    return $(all) ;    
+                odr_emulation ] ;
+    all += [ run odr_no_uns1.cpp odr_no_uns2.cpp : : : <define>BOOST_TYPEOF_EMULATION :
+                odr_no_uns ] ;
+    return $(all) ;
 }
 
-test-suite "typeof" 
+test-suite "typeof"
 	:  [ all-tests ]
     ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -10,7 +10,6 @@ import set ;
 
 project : requirements
     <library>/boost/core//boost_core
-    <library>/boost/lexical_cast//boost_lexical_cast
     ;
 
 # The special requirement is not ported yet.


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.